### PR TITLE
Add "extended" parameter in configuration

### DIFF
--- a/src/Bundle/DependencyInjection/PhraseanetConfiguration.php
+++ b/src/Bundle/DependencyInjection/PhraseanetConfiguration.php
@@ -46,6 +46,7 @@ class PhraseanetConfiguration implements ConfigurationInterface
                                 ->scalarNode('token')->end()
                             ->end()
                         ->end()
+                        ->booleanNode('extended')->defaultTrue()->end()
                         ->scalarNode('uploader')->end()
                         ->append((new CacheNodeBuilder())->getNode())
                         ->append((new MappingNodeBuilder('mappings'))->getNode())

--- a/src/Bundle/DependencyInjection/PhraseanetExtension.php
+++ b/src/Bundle/DependencyInjection/PhraseanetExtension.php
@@ -96,7 +96,9 @@ class PhraseanetExtension extends ConfigurableExtension
             $configuration['connection']['secret'],
         ]);
 
-        $application->addMethodCall('setExtendedMode', [true]);
+        if (isset($configuration['extended']) && $configuration['extended']) {
+            $application->addMethodCall('setExtendedMode', [true]);
+        }
 
         $tokenProvider = new Definition(ChainedTokenProvider::class);
 


### PR DESCRIPTION
Allows toggling of extended mode in API responses
